### PR TITLE
Add new class "BaseIdentityServices" to add version to URL

### DIFF
--- a/core-test/src/main/java/org/openstack4j/api/heat/StackServiceTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/heat/StackServiceTests.java
@@ -1,0 +1,51 @@
+package org.openstack4j.api.heat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.openstack4j.api.AbstractTest;
+import org.openstack4j.model.heat.AdoptStackData;
+import org.openstack4j.model.heat.Stack;
+import org.openstack4j.openstack.heat.domain.HeatAdoptStackData;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Heat Stack Services function
+ *
+ * @author Ales Kemr
+ */
+@Test(suiteName="heat/stacks", enabled = true)
+public class StackServiceTests extends AbstractTest {
+
+    private static final String JSON_ABANDON = "/heat/abandon.json";
+    private static final String JSON_ADOPT = "/heat/adopt.json";
+    
+    public void testAbandonStack() throws Exception {
+        respondWith(JSON_ABANDON);
+        
+        AdoptStackData adoptStackData = osv3().heat().stacks().abandon("stack_123", "416c09e9-2022-4d43-854b-0292ddff3f5d");
+        takeRequest();
+        
+        assertEquals(adoptStackData.getName(), "stack_123");
+        assertEquals(adoptStackData.getStatus(), "COMPLETE");
+        final Map<String, Object> portResource = adoptStackData.getResources().get("network_port");
+        assertEquals(portResource.get("type"), "OS::Neutron::Port");
+    }
+    
+    public void testAdoptStack() throws Exception {
+        respondWith(JSON_ADOPT);
+        
+        AdoptStackData adoptStackData = new ObjectMapper().readValue(getResource(JSON_ABANDON), HeatAdoptStackData.class);
+        Stack adoptedStack = osv3().heat().stacks().adopt(adoptStackData, new HashMap<String, String>(), false, 30L, null);
+        takeRequest();
+        
+        assertEquals(adoptedStack.getId(), "79370050-6038-4ea2-baaa-3e4706d59e0e");
+    }
+
+    @Override
+    protected Service service() {
+        return Service.ORCHESTRATION;
+    }
+
+}

--- a/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
@@ -1,6 +1,5 @@
 package org.openstack4j.api.network;
 
-import static org.junit.Assert.assertFalse;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -14,12 +13,10 @@ import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
 import org.openstack4j.model.network.Agent;
 import org.openstack4j.model.network.Agent.Type;
-import org.openstack4j.model.storage.block.VolumeBackup;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.NetworkType;
 import org.openstack4j.model.network.State;
 import org.openstack4j.model.common.ActionResponse;
-import org.testng.Reporter;
 import org.testng.annotations.Test;
 
 import okhttp3.mockwebserver.RecordedRequest;
@@ -91,14 +88,6 @@ public class NetworkTests extends AbstractTest {
         assertEquals(agent.getAgentType(), Type.DHCP);
     }
 
-    @Test
-    public void attachNetworkToDhcpAgent() throws Exception {
-        respondWith(201);
-        ActionResponse result = osv3().networking().agent().attachNetworkToDhcpAgent("190ecbc2-77e0-4e4f-a96b-aa849edb357b", "4e8e5957-649f-477b-9e5b-f1f75b21c03c");
-        server.takeRequest();
-        assertTrue(result.isSuccess());
-    }
-    
     @Test
     public void detachNetworkToDhcpAgent() throws Exception {
         respondWith(204);

--- a/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
@@ -1,22 +1,28 @@
 package org.openstack4j.api.network;
 
+import static org.junit.Assert.assertFalse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import okhttp3.mockwebserver.RecordedRequest;
+
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
-import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Agent;
 import org.openstack4j.model.network.Agent.Type;
+import org.openstack4j.model.storage.block.VolumeBackup;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.NetworkType;
 import org.openstack4j.model.network.State;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import org.openstack4j.model.common.ActionResponse;
+import org.testng.Reporter;
 import org.testng.annotations.Test;
+
+import okhttp3.mockwebserver.RecordedRequest;
 
 /**
  * Tests the Compute -> Network API against the mock webserver and spec based
@@ -83,6 +89,14 @@ public class NetworkTests extends AbstractTest {
 		assertEquals(agent.getCreatedAt(), (new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")).parse("2015-03-18 20:28:02"));
         assertEquals(agent.getAgentType(), Type.DHCP);
         assertEquals(agent.getAgentType(), Type.DHCP);
+    }
+
+    @Test
+    public void attachNetworkToDhcpAgent() throws Exception {
+        respondWith(201);
+        ActionResponse result = osv3().networking().agent().attachNetworkToDhcpAgent("190ecbc2-77e0-4e4f-a96b-aa849edb357b", "4e8e5957-649f-477b-9e5b-f1f75b21c03c");
+        server.takeRequest();
+        assertTrue(result.isSuccess());
     }
     
     @Test

--- a/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
+++ b/core-test/src/main/java/org/openstack4j/api/network/NetworkTests.java
@@ -1,27 +1,22 @@
 package org.openstack4j.api.network;
 
-import static org.junit.Assert.assertFalse;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import okhttp3.mockwebserver.RecordedRequest;
 import org.openstack4j.api.AbstractTest;
 import org.openstack4j.api.Builders;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Agent;
 import org.openstack4j.model.network.Agent.Type;
-import org.openstack4j.model.storage.block.VolumeBackup;
 import org.openstack4j.model.network.Network;
 import org.openstack4j.model.network.NetworkType;
 import org.openstack4j.model.network.State;
-import org.testng.Reporter;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
-
-import okhttp3.mockwebserver.RecordedRequest;
 
 /**
  * Tests the Compute -> Network API against the mock webserver and spec based
@@ -88,6 +83,14 @@ public class NetworkTests extends AbstractTest {
 		assertEquals(agent.getCreatedAt(), (new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")).parse("2015-03-18 20:28:02"));
         assertEquals(agent.getAgentType(), Type.DHCP);
         assertEquals(agent.getAgentType(), Type.DHCP);
+    }
+    
+    @Test
+    public void detachNetworkToDhcpAgent() throws Exception {
+        respondWith(204);
+        ActionResponse result = osv3().networking().agent().detachNetworkToDhcpAgent("190ecbc2-77e0-4e4f-a96b-aa849edb357b", "4e8e5957-649f-477b-9e5b-f1f75b21c03c");
+        server.takeRequest();
+        assertTrue(result.isSuccess());
     }
 
     @Override

--- a/core-test/src/main/java/org/openstack4j/openstack/common/ServiceTypeTest.java
+++ b/core-test/src/main/java/org/openstack4j/openstack/common/ServiceTypeTest.java
@@ -13,6 +13,8 @@ public class ServiceTypeTest {
 
    private Map<ServiceType, Collection<String>> types;
 
+    private Map<ServiceType, Collection<String>> unknownTypes;
+
    @BeforeSuite
    public void setup() {
        types = new HashMap<>();
@@ -37,6 +39,10 @@ public class ServiceTypeTest {
        types.put(ServiceType.MAGNUM, Arrays.asList("container","ContainerV3","containerv1"));
        types.put(ServiceType.DNS, Arrays.asList("dns","dnsv2","dnsV3"));
        types.put(ServiceType.WORKFLOW, Arrays.asList("workflow","workflowv3","workflowv2"));
+
+       unknownTypes = new HashMap();
+       unknownTypes.put(ServiceType.ORCHESTRATION, Arrays.asList("heat-cfg","heatother","heatvm","heat-cfg4"));
+
    }
 
    @Test
@@ -47,4 +53,13 @@ public class ServiceTypeTest {
            }
        }
    }
+
+    @Test
+    public void testNameNotResolved() {
+        for (Map.Entry<ServiceType, Collection<String>> entry : unknownTypes.entrySet()) {
+            for(String type : entry.getValue()){
+                assertEquals(ServiceType.UNKNOWN, ServiceType.forName(type));
+            }
+        }
+    }
 }

--- a/core-test/src/main/resources/heat/abandon.json
+++ b/core-test/src/main/resources/heat/abandon.json
@@ -1,0 +1,55 @@
+{
+   "files":{
+
+   },
+   "status":"COMPLETE",
+   "name":"stack_123",
+   "tags":null,
+   "stack_user_project_id":"44ed5c0be2384092b8e8b6444812db5d",
+   "environment":{
+      "event_sinks":[
+
+      ],
+      "parameter_defaults":{
+
+      },
+      "parameters":{
+
+      },
+      "resource_registry":{
+         "resources":{
+
+         }
+      }
+   },
+   "template":{
+      "heat_template_version":"2016-04-08",
+      "description":"A heat test template",
+      "resources":{
+         "network_port":{
+            "type":"OS::Neutron::Port",
+            "properties":{
+               "network_id":"network123"
+            }
+         }
+      }
+   },
+   "action":"CREATE",
+   "project_id":"0dbd25a2a75347cf88a0a52638b8fff3",
+   "id":"416c09e9-2022-4d43-854b-0292ddff3f5d",
+   "resources":{
+      "network_port":{
+         "status":"COMPLETE",
+         "name":"network_port",
+         "resource_data":{
+
+         },
+         "resource_id":"1d0dccbb-0c99-48cd-b41b-abeca3ac6a42",
+         "action":"CREATE",
+         "type":"OS::Neutron::Port",
+         "metadata":{
+
+         }
+      }
+   }
+}

--- a/core-test/src/main/resources/heat/adopt.json
+++ b/core-test/src/main/resources/heat/adopt.json
@@ -1,0 +1,11 @@
+{
+   "stack":{
+      "id":"79370050-6038-4ea2-baaa-3e4706d59e0e",
+      "links":[
+         {
+            "href":"http://any.os.com:8004/v1/0dbd25a2a75347cf88a0a52638b8fff3/stacks/stack_123/79370050-6038-4ea2-baaa-3e4706d59e0e",
+            "rel":"self"
+         }
+      ]
+   }
+}

--- a/core-test/src/main/resources/identity/v2/access.json
+++ b/core-test/src/main/resources/identity/v2/access.json
@@ -148,6 +148,25 @@
 						"adminURL": "http:\/\/127.0.0.1:8087\/v2.0",
 						"region": "RegionOne",
 						"internalURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"id": "9c66xrg3gruv2a3hj8aatd7smmas23fy",
+						"publicURL": "http:\/\/127.0.0.1:8087\/v2.0"
+					}, {
+						"adminURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"region": "RegionTwo",
+						"internalURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"id": "9c66xrgerruv2a3hj8batd7smmas23fy",
+						"publicURL": "http:\/\/127.0.0.1:8087\/v2.0"
+					}
+				],
+				"endpoints_links": [],
+				"type": "aodh",
+				"name": "alarming"
+			}, {
+				"endpoints": [
+					{
+						"adminURL": "http:\/\/127.0.0.1:8087\/v2.0",
+						"region": "RegionOne",
+						"internalURL": "http:\/\/127.0.0.1:8087\/v2.0",
 						"id": "9c66xrg3rruv2a3hj8tatd7smmas23fy",
 						"publicURL": "http:\/\/127.0.0.1:8087\/v2.0"
 					}, {

--- a/core-test/src/main/resources/identity/v3/authv3_project.json
+++ b/core-test/src/main/resources/identity/v3/authv3_project.json
@@ -477,9 +477,37 @@
             "id": "123450a4597040849c03bc1358854321"
           }
         ],
-        "type": "telemetry",
+        "type": "alarming",
         "id": "1236500210a24c38a3702b6825e12345",
-        "name": "ceilometeter"
+        "name": "aodh"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f40a09df51035681d5678"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "12345321ae80458abc3728fa1e6f1234"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123450a4597040859c03bc1358854321"
+          }
+        ],
+        "type": "metering",
+        "id": "1236500210a24c38a3702b6835e12345",
+        "name": "ceilometer"
       },
       {
         "endpoints": [

--- a/core-test/src/main/resources/identity/v3/authv3_project.json
+++ b/core-test/src/main/resources/identity/v3/authv3_project.json
@@ -485,6 +485,34 @@
         "endpoints": [
           {
             "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "public",
+            "id": "123458912d3f49a09df51035681d59a8"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "admin",
+            "id": "123453dd1ae80457abc3728fa1e6f123"
+          },
+          {
+            "region_id": "RegionOne",
+            "url": "http://127.0.0.1:8087",
+            "region": "RegionOne",
+            "interface": "internal",
+            "id": "123451a45a7040849c03bc1358854321"
+          }
+        ],
+        "type": "aodh",
+        "id": "1236500210a24c38a1702e6825e12345",
+        "name": "alarming"
+      },
+      {
+        "endpoints": [
+          {
+            "region_id": "RegionOne",
             "url": "http://127.0.0.1:8082",
             "region": "RegionOne",
             "interface": "public",

--- a/core-test/src/main/resources/telemetry/alarm.json
+++ b/core-test/src/main/resources/telemetry/alarm.json
@@ -1,4 +1,4 @@
-[{
+{
 		"alarm_id" : "03757eede9c540338e732d1a7fb07966",
 		"enabled": false,
 		"name": "name_post",
@@ -27,4 +27,3 @@
 			"granularity": 180
 		}
 	}
-]

--- a/core-test/src/main/resources/telemetry/alarm.json
+++ b/core-test/src/main/resources/telemetry/alarm.json
@@ -1,30 +1,29 @@
-[{
-		"alarm_id" : "03757eede9c540338e732d1a7fb07966",
-		"enabled": false,
-		"name": "name_post",
-		"state": "ok",
-		"type": "gnocchi_aggregation_by_metrics_threshold",
-		"severity": "critical",
-		"ok_actions": [
-			"http://something/ok"
+{
+	"alarm_id" : "03757eede9c540338e732d1a7fb07966",
+	"enabled": false,
+	"name": "name_post",
+	"state": "ok",
+	"type": "gnocchi_aggregation_by_metrics_threshold",
+	"severity": "critical",
+	"ok_actions": [
+		"http://something/ok"
+	],
+	"alarm_actions": [
+		"http://something/alarm"
+	],
+	"insufficient_data_actions": [
+		"http://something/no"
+	],
+	"repeat_actions": true,
+	"gnocchi_aggregation_by_metrics_threshold_rule": {
+		"metrics": [
+			"b3d9d8ab-05e8-439f-89ad-5e978dd2a5eb",
+			"009d4faf-c275-46f0-8f2d-670b15bac2b0"
 		],
-		"alarm_actions": [
-			"http://something/alarm"
-		],
-		"insufficient_data_actions": [
-			"http://something/no"
-		],
-		"repeat_actions": true,
-		"gnocchi_aggregation_by_metrics_threshold_rule": {
-			"metrics": [
-				"b3d9d8ab-05e8-439f-89ad-5e978dd2a5eb",
-				"009d4faf-c275-46f0-8f2d-670b15bac2b0"
-			],
-			"comparison_operator": "le",
-			"aggregation_method": "count",
-			"threshold": 50,
-			"evaluation_periods": 3,
-			"granularity": 180
-		}
+		"comparison_operator": "le",
+		"aggregation_method": "count",
+		"threshold": 50,
+		"evaluation_periods": 3,
+		"granularity": 180
 	}
-]
+}

--- a/core/src/main/java/org/openstack4j/api/heat/StackService.java
+++ b/core/src/main/java/org/openstack4j/api/heat/StackService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.heat.AdoptStackData;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.heat.StackCreate;
 import org.openstack4j.model.heat.StackUpdate;
@@ -100,5 +101,26 @@ public interface StackService {
 	 */
 	ActionResponse delete(String stackName, String stackId);
 
-
+        /**
+         * Deletes a stack but leaves its resources intact, and returns data that describes the stack and its resources.
+         * 
+         * @param stackName Name of {@link Stack}
+         * @param stackId Id of {@link Stack}
+         * 
+         * @return <code>adopt_stack_data</code> element representing by {@link AdoptStackData}
+         */
+        AdoptStackData abandon(String stackName, String stackId);
+        
+        /**
+         * Creates a stack from existing resources.
+         * 
+         * @param adoptStackData Structure {@link AdoptStackData}, representing existing resources
+         * @param parameters Map of parameters
+         * @param disableRollback Enable or disable rollback
+         * @param timeOutMins Timeout in minutes
+         * @param template Template in Json-Format or YAML format. It is optional, used just in case there will be new resources (not included in adoptStackData)
+         * @return 
+         */
+        Stack adopt(AdoptStackData adoptStackData, Map<String, String> parameters,
+			boolean disableRollback, Long timeOutMins, String template);
 }

--- a/core/src/main/java/org/openstack4j/api/networking/ext/AgentService.java
+++ b/core/src/main/java/org/openstack4j/api/networking/ext/AgentService.java
@@ -1,8 +1,8 @@
 package org.openstack4j.api.networking.ext;
 
 import java.util.List;
-
 import org.openstack4j.common.RestService;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Agent;
 
 /**
@@ -35,5 +35,21 @@ public interface AgentService extends RestService {
      * @return a new reference to the updated agent
      */
     Agent setAdminStateUp(String agentId, boolean state);
+    
+    /**
+     * Schedules the network to that the specified DHCP agent.
+     * @param agentId the id of agent with type DHCP
+     * @param networkId the id of network 
+     * @return the action response
+     */
+    ActionResponse attachNetworkToDhcpAgent(String agentId, String networkId);
+    
+    /**
+     * Removes the network from that the specified DHCP agent.
+     * @param agentId the id of agent with type DHCP
+     * @param networkId the id of network 
+     * @return the action response
+     */
+    ActionResponse detachNetworkToDhcpAgent(String agentId, String networkId);
 
 }

--- a/core/src/main/java/org/openstack4j/api/types/ServiceType.java
+++ b/core/src/main/java/org/openstack4j/api/types/ServiceType.java
@@ -1,5 +1,6 @@
 package org.openstack4j.api.types;
 
+import java.util.regex.Pattern;
 public enum ServiceType {
 
 	IDENTITY("keystone", "identity"),
@@ -29,11 +30,17 @@ public enum ServiceType {
 
 	private final String serviceName;
 	private final String type;
+    private final Pattern servicePattern;
+    private static final String SERVICE_PATTERN_SUFFIX = "[v|\\d|\\.]*";
 
 	ServiceType(String serviceName, String type) {
 		this.serviceName = serviceName;
 		this.type = type;
-	}
+        this.servicePattern = Pattern.compile(Pattern.quote(serviceName) + SERVICE_PATTERN_SUFFIX +
+                        "|" + Pattern.quote(type) + SERVICE_PATTERN_SUFFIX +
+                        "|" + Pattern.quote(this.name()) + SERVICE_PATTERN_SUFFIX
+                , Pattern.CASE_INSENSITIVE);
+    }
 
 	public String getServiceName() {
 		return this.serviceName;
@@ -43,22 +50,22 @@ public enum ServiceType {
 		return this.type;
 	}
 
-	public static ServiceType forName(String name) {
-            if (name == null || name.isEmpty()) {
-                return ServiceType.UNKNOWN;
-            }
+    private Pattern getServicePattern()
+    {
+        return this.servicePattern;
+    }
 
-            for (ServiceType s : ServiceType.values()) {
-                if (name.toLowerCase().startsWith(s.getServiceName().toLowerCase())) {
-                    return s;
-                }
-                if (name.toLowerCase().startsWith(s.name().toLowerCase())) {
-                    return s;
-                }
-                if (name.toLowerCase().startsWith(s.type.toLowerCase())) {
-                    return s;
-                }
-            }
+    public static ServiceType forName(String name)
+    {
+        if (name == null || name.isEmpty())
+        {
             return ServiceType.UNKNOWN;
         }
+        for (ServiceType s : ServiceType.values())
+        {
+            if(s.getServicePattern().matcher(name).matches())
+                return s;
+        }
+        return ServiceType.UNKNOWN;
+    }
 }

--- a/core/src/main/java/org/openstack4j/model/heat/AdoptStackData.java
+++ b/core/src/main/java/org/openstack4j/model/heat/AdoptStackData.java
@@ -1,0 +1,59 @@
+package org.openstack4j.model.heat;
+
+import java.util.Map;
+import org.openstack4j.model.ModelEntity;
+
+/**
+ * This interface describes <code>adopt_stack_data</code> element. It is used
+ * for stack adoption and as a return value for stack abandoning. All getters
+ * map to the possible return values of
+ * <code> Delete /v1/{tenant_id}/stacks/{stack_name}/{stack_id}/abandon</code>
+ *
+ * @see https://developer.openstack.org/api-ref/orchestration/v1
+ *
+ * @author Ales Kemr
+ */
+public interface AdoptStackData extends ModelEntity {
+
+    /**
+     * Returns stack action, e.g. CREATE
+     * 
+     * @return stack action
+     */
+    String getAction();
+
+    /**
+     * Returns the id of the stack
+     *
+     * @return the id of the stack
+     */
+    String getId();
+
+    /**
+     * Returns the name of the stack
+     *
+     * @return the name of the stack
+     */
+    String getName();
+
+    /**
+     * Returns the status of the stack
+     *
+     * @return the status of the stack
+     */
+    String getStatus();
+
+    /**
+     * Returns stack template as a map
+     *
+     * @return stack template as a map
+     */
+    Map<String, Object> getTemplate();
+
+    /**
+     * Returns map of existing resources, to be adopted into the stack
+     *
+     * @return Map of existing resources to be adopted into the stack
+     */
+    Map<String, Map<String, Object>> getResources();
+}

--- a/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
@@ -2,6 +2,7 @@ package org.openstack4j.openstack.heat.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import java.util.Map;
 import org.openstack4j.model.heat.AdoptStackData;
 
@@ -65,7 +66,12 @@ public class HeatAdoptStackData implements AdoptStackData {
 
     @Override
     public String toString() {
-        return "HeatAdoptStackData{" + "id=" + id + ", name=" + name + ", status=" + status + ", resources=" + resources + '}';
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                .add("id", id)
+                .add("name", name)
+                .add("status", status)
+                .add("resources", resources)
+                .toString();
     }
 
     public static HeatAdoptStackDataBuilder builder() {

--- a/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatAdoptStackData.java
@@ -1,0 +1,123 @@
+package org.openstack4j.openstack.heat.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import org.openstack4j.model.heat.AdoptStackData;
+
+/**
+ * This class contains all elements required for the creation of <code>adopt_stack_data</code> element. It is used for stack adoption and as a return value for stack abandoning.
+ * It uses Jackson annotation for (de)serialization into JSON.
+ * 
+ * @author Ales Kemr
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HeatAdoptStackData implements AdoptStackData {
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("action")
+    private String action;
+    
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("name")
+    private String name;
+    
+    @JsonProperty("status")
+    private String status;
+    
+    @JsonProperty("template")
+    private Map<String,Object> template;
+    
+    @JsonProperty("resources")
+    private Map<String, Map<String, Object>> resources;
+
+    @Override
+    public String getAction() {
+        return action;
+    }
+    
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getStatus() {
+        return status;
+    }
+
+    @Override
+    public Map<String,Object> getTemplate() {
+        return template;
+    }
+
+    @Override
+    public Map<String, Map<String, Object>> getResources() {
+        return resources;
+    }
+
+    @Override
+    public String toString() {
+        return "HeatAdoptStackData{" + "id=" + id + ", name=" + name + ", status=" + status + ", resources=" + resources + '}';
+    }
+
+    public static HeatAdoptStackDataBuilder builder() {
+        return new HeatAdoptStackDataBuilder();
+    }
+
+    public static class HeatAdoptStackDataBuilder {
+
+        private HeatAdoptStackData model;
+
+        public HeatAdoptStackDataBuilder() {
+            this.model = new HeatAdoptStackData();
+        }
+
+        public HeatAdoptStackDataBuilder(HeatAdoptStackData model) {
+            this.model = model;
+        }
+
+        public HeatAdoptStackDataBuilder action(String action) {
+            this.model.action = action;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder id(String id) {
+            this.model.id = id;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder name(String name) {
+            this.model.name = name;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder status(String status) {
+            this.model.status = status;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder template(Map<String,Object> template) {
+            this.model.template = template;
+            return this;
+        }
+
+        public HeatAdoptStackDataBuilder resources(Map<String, Map<String, Object>> resources) {
+            this.model.resources = resources;
+            return this;
+        }
+
+        public HeatAdoptStackData build() {
+            return model;
+        }
+    }
+
+    
+}

--- a/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatStackAdopt.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/domain/HeatStackAdopt.java
@@ -1,0 +1,116 @@
+package org.openstack4j.openstack.heat.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openstack4j.model.ModelEntity;
+import org.openstack4j.model.heat.AdoptStackData;
+
+/**
+ * This class contains all elements required for the adoption of a HeatStack. It
+ * uses Jackson annotation for (de)serialization into JSON
+ * 
+ * @author Ales Kemr
+ */
+public class HeatStackAdopt implements ModelEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("stack_name")
+    private String name;
+    @JsonProperty("timeout_mins")
+    private Long timeoutMins;
+    @JsonProperty("parameters")
+    private Map<String, String> parameters;
+    @JsonProperty("disable_rollback")
+    private boolean disableRollback;
+    @JsonProperty("adopt_stack_data")
+    private String adoptStackData;
+    @JsonProperty("template")
+    private String template;
+
+    public String getName() {
+        return name;
+    }
+
+    public Long getTimeoutMins() {
+        return timeoutMins;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public boolean isDisableRollback() {
+        return disableRollback;
+    }
+
+    public String getAdoptStackData() {
+        return adoptStackData;
+    }
+
+    public String getTemplate() {
+        return template;
+    }
+    
+    public static HeatStackAdoptBuilder builder() {
+        return new HeatStackAdoptBuilder();
+    }
+
+    public static class HeatStackAdoptBuilder {
+
+        private HeatStackAdopt model;
+
+        public HeatStackAdoptBuilder(HeatStackAdopt model) {
+            this.model = model;
+        }
+
+        public HeatStackAdoptBuilder() {
+            this.model = new HeatStackAdopt();
+        }
+        
+        public HeatStackAdoptBuilder name(String name) {
+            this.model.name = name;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder timeoutMins(Long timeoutMins) {
+            this.model.timeoutMins = timeoutMins;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder parameters(Map<String, String> parameters) {
+            this.model.parameters = parameters;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder disableRollback(boolean disableRollback) {
+            this.model.disableRollback = disableRollback;
+            return this;
+        }
+
+        public HeatStackAdoptBuilder adoptStackData(AdoptStackData adoptStackData) {
+            try {
+                this.model.adoptStackData = new ObjectMapper().writeValueAsString(adoptStackData);
+                return this;
+            } catch (JsonProcessingException ex) {
+                Logger.getLogger(HeatStackAdopt.class.getName()).log(Level.SEVERE, null, ex);
+                throw new RuntimeException(ex);
+            }
+        }
+        
+        public HeatStackAdoptBuilder template(String template) {
+            this.model.template = template;
+            return this;
+        }
+
+        public HeatStackAdopt build() {
+            return model;
+        }
+    }
+    
+    
+}

--- a/core/src/main/java/org/openstack4j/openstack/heat/internal/StackServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/heat/internal/StackServiceImpl.java
@@ -3,11 +3,14 @@ package org.openstack4j.openstack.heat.internal;
 import org.openstack4j.api.Builders;
 import org.openstack4j.api.heat.StackService;
 import org.openstack4j.model.common.ActionResponse;
+import org.openstack4j.model.heat.AdoptStackData;
 import org.openstack4j.model.heat.Stack;
 import org.openstack4j.model.heat.StackCreate;
 import org.openstack4j.model.heat.StackUpdate;
 import org.openstack4j.openstack.compute.functions.ToActionResponseFunction;
+import org.openstack4j.openstack.heat.domain.HeatAdoptStackData;
 import org.openstack4j.openstack.heat.domain.HeatStack;
+import org.openstack4j.openstack.heat.domain.HeatStackAdopt;
 import org.openstack4j.openstack.heat.domain.HeatStack.Stacks;
 
 import java.util.List;
@@ -90,4 +93,26 @@ public class StackServiceImpl extends BaseHeatServices implements StackService {
         checkNotNull(stackName);
         return get(HeatStack.class, uri("/stacks/%s", stackName)).execute();
     }
+    
+    @Override
+    public AdoptStackData abandon(String stackName, String stackId) {
+        checkNotNull(stackId);
+        return delete(HeatAdoptStackData.class, uri("/stacks/%s/%s/abandon", stackName, stackId)).execute();
+    }
+
+    @Override
+    public Stack adopt(AdoptStackData adoptStackData, Map<String, String> parameters, boolean disableRollback, Long timeoutMins, String template) {
+        checkNotNull(adoptStackData);
+        checkNotNull(parameters);
+        checkNotNull(timeoutMins);
+        HeatStackAdopt heatStackAdopt = HeatStackAdopt.builder()
+                .adoptStackData(adoptStackData)
+                .template(template)
+                .disableRollback(disableRollback)
+                .name(adoptStackData.getName())
+                .parameters(parameters)
+                .timeoutMins(timeoutMins)
+                .build();
+        return post(HeatStack.class, uri("/stacks")).entity(heatStackAdopt).execute();
+    }    
 }

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
@@ -15,3 +15,4 @@ public class BaseIdentityServices extends BaseOpenStackService {
                 super(ServiceType.IDENTITY, EnforceVersionToURL.instance("/v3"));
         }
 }
+

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/BaseIdentityServices.java
@@ -1,0 +1,17 @@
+package org.openstack4j.openstack.identity.v3.internal;
+
+import org.openstack4j.api.types.ServiceType;
+import org.openstack4j.openstack.common.functions.EnforceVersionToURL;
+import org.openstack4j.openstack.internal.BaseOpenStackService;
+
+/**
+ * Base Identity Operations Implementation is responsible for insuring the proper endpoint is used for all extending operation APIs
+ *
+ * @author Jyothi Saroja
+ */
+public class BaseIdentityServices extends BaseOpenStackService {
+
+        protected BaseIdentityServices() {
+                super(ServiceType.IDENTITY, EnforceVersionToURL.instance("/v3"));
+        }
+}

--- a/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/IdentityServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/identity/v3/internal/IdentityServiceImpl.java
@@ -8,13 +8,12 @@ import org.openstack4j.api.Apis;
 import org.openstack4j.api.identity.v3.*;
 import org.openstack4j.model.common.Extension;
 import org.openstack4j.openstack.common.ExtensionValue.ExtensionList;
-import org.openstack4j.openstack.internal.BaseOpenStackService;
 
 /**
  * Identity V3 service implementation
  *
  */
-public class IdentityServiceImpl extends BaseOpenStackService implements IdentityService {
+public class IdentityServiceImpl extends BaseIdentityServices implements IdentityService {
 
     @Override
     public CredentialService credentials() {

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSubnetUpdate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSubnetUpdate.java
@@ -6,6 +6,7 @@ import org.openstack4j.model.ModelEntity;
 import org.openstack4j.model.network.Subnet;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 

--- a/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSubnetUpdate.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/domain/NeutronSubnetUpdate.java
@@ -29,6 +29,7 @@ public class NeutronSubnetUpdate implements ModelEntity {
     @JsonProperty("host_routes")
     private List<NeutronHostRoute> hostRoutes;
     @JsonProperty("gateway_ip")
+    @JsonInclude
     private String gateway;
     @JsonProperty("enable_dhcp")
     private boolean enabledhcp;

--- a/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/AgentServiceImpl.java
+++ b/core/src/main/java/org/openstack4j/openstack/networking/internal/ext/AgentServiceImpl.java
@@ -1,12 +1,11 @@
 package org.openstack4j.openstack.networking.internal.ext;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
-
 import org.openstack4j.api.networking.ext.AgentService;
 import org.openstack4j.core.transport.ExecutionOptions;
 import org.openstack4j.core.transport.propagation.PropagateOnStatus;
+import org.openstack4j.model.common.ActionResponse;
 import org.openstack4j.model.network.Agent;
 import org.openstack4j.openstack.networking.domain.NeutronAgent;
 import org.openstack4j.openstack.networking.domain.NeutronAgent.Agents;
@@ -36,5 +35,18 @@ public class AgentServiceImpl extends BaseNetworkingServices implements AgentSer
         String json = String.format("{\"%s\": { \"%s\": \"%b\"}}", "agent", "admin_state_up", state);
         return put(NeutronAgent.class, uri("/agents/%s", agentId)).json(json).execute(
                 ExecutionOptions.<NeutronAgent> create(PropagateOnStatus.on(404)));
+    }
+
+    @Override
+    public ActionResponse attachNetworkToDhcpAgent(String agentId, String networkId) {
+        checkNotNull(agentId);
+        String json = String.format("{\"%s\": \"%s\"}", "network_id", networkId);
+        return postWithResponse(uri("/agents/%s/dhcp-networks", agentId)).json(json).execute(ExecutionOptions.<ActionResponse> create(PropagateOnStatus.on(404)));
+    }
+    
+    @Override
+    public ActionResponse detachNetworkToDhcpAgent(String agentId, String networkId) {
+        checkNotNull(agentId);
+        return deleteWithResponse(uri("/agents/%s/dhcp-networks/%s", agentId, networkId)).execute(ExecutionOptions.<ActionResponse> create(PropagateOnStatus.on(404)));
     }
 }


### PR DESCRIPTION
The code below fixes the github issue #1198: "Identity service not working with OS4j".
The keystone version v3 is missed in the keystone endpoint URL due to which the Identity service APIs fail with the error message "Resource could not be found (404)". The code appends version "/v3" to the keystone endpoint URL which fixes the issue.